### PR TITLE
Tell travis-ci to use 7.8.3 and ghc head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ env:
   - GHCVER=7.8.3
   - GHCVER=head
 
+matrix:
+  allow_failures:
+    - env: GHCVER=head
+
 before_install:
   # If $GHCVER is the one travis has, don't bother reinstalling it.
   # We can also have faster builds by installing some libraries with


### PR DESCRIPTION
I believe this is needed after c15afbb26022f27aa1dee1a3e16eddc2324f8898.
